### PR TITLE
Included cordova version

### DIFF
--- a/tutorials/fullscreen-apps/index.md
+++ b/tutorials/fullscreen-apps/index.md
@@ -21,7 +21,7 @@ Fullscreen apps on iOS
       fullscreen in Ionic is simple!
     </p>
     <p>
-      First, we need to note this only works on Cordova or another native UIWebView wrapper. If we use Cordova,
+      First, we need to note this only works on Cordova (3.3.1) or another native UIWebView wrapper. If we use Cordova,
       we will need to install one plugin:
     </p>
     <p>


### PR DESCRIPTION
Included cordova version in docs as this plugin throws errors with 3.3.0 and took me a while to figure out what's wrong. Hopefully this might save someone else time.
