### PR TITLE
Added script reference to angular-ui-router.js

### DIFF
--- a/docs/guide/starting.md
+++ b/docs/guide/starting.md
@@ -31,6 +31,7 @@ Since every Ionic app is basically a web page, we need to have an `index.html` f
     <script src="js/angular/angular-route.js"></script>
     <script src="js/angular/angular-touch.js"></script>
     <script src="js/angular/angular-sanitize.js"></script>
+    <script src="js/angular-ui/angular-ui-router.js"></script>
     <script src="js/ionic-angular.js"></script>
     
     <!-- Needed for Cordova/PhoneGap -->


### PR DESCRIPTION
Without this change I was getting:
Uncaught Error: [$injector:modulerr] Failed to instantiate module todo due to:
Error: [$injector:modulerr] Failed to instantiate module ionic due to:
Error: [$injector:modulerr] Failed to instantiate module ionic.service due to:
Error: [$injector:modulerr] Failed to instantiate module ionic.service.view due to:
Error: [$injector:modulerr] Failed to instantiate module ui.router due to:
Error: [$injector:nomod] Module 'ui.router' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
