### PR TITLE
create a new task object before showing the taskModal

### DIFF
--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -170,6 +170,7 @@ angular.module('todo', ['ionic'])
 
   // Open our new task modal
   $scope.newTask = function() {
+    $scope.task = {};
     $scope.taskModal.show();
   };
 


### PR DESCRIPTION
Without this I get an `Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed` if I add more than one task to the Creating Tasks example, because each time $scope.createTask is called, the same $scope.task object (with an updated title) is pushed onto the array. Alternatively, you could set`ng-submit="createTask({title: task.title})"` instead of `createTask(task)`, but setting `$scope.task = {}` before showing the dialog also clears the task title so you see the placeholder text, which is nice.
