### PR TITLE
Removed wrapping button tag

### DIFF
--- a/docs/components/index.html
+++ b/docs/components/index.html
@@ -614,13 +614,11 @@ news: Need icons? Check out <a href="http://ionicons.com/">Ionicons</a>, our cus
   </p>
 
 {% highlight html %}
-<button class="button button-icon">
-  <div class="bar bar-header">
-    <button class="button button-icon icon ion-navicon"></button>
-    <div class="h1 title">Header Buttons</div>
-    <button class="button button-clear button-positive">Edit</button>
-  </div>
-</button>
+<div class="bar bar-header">
+  <button class="button button-icon icon ion-navicon"></button>
+  <div class="h1 title">Header Buttons</div>
+  <button class="button button-clear button-positive">Edit</button>
+</div>
 {% endhighlight %}
 
   <div class="doc-example ionic">


### PR DESCRIPTION
I assume the wrapping button tag is wrong here!?

``` css
<button class="button button-icon">
  <div class="bar bar-header">
    <button class="button button-icon icon ion-navicon"></button>
    <div class="h1 title">Header Buttons</div>
    <button class="button button-clear button-positive">Edit</button>
  </div>
</button>
```
