### PR TITLE
Update attributes of Slide Box docs page

### DIFF
--- a/docs/angularjs/views/slide-box/index.md
+++ b/docs/angularjs/views/slide-box/index.md
@@ -17,6 +17,57 @@ The Slide Box is a multi-page container where each page can be swiped or dragged
 
 <img src="http://ionicframework.com.s3.amazonaws.com/docs/controllers/slideBox.gif">
 
+## \<ion-slide-box\>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>show-pager</td>
+      <td><b>boolean</b></td>
+      <td>true</td>
+      <td>Whether to show or hide the pager icons</td>
+    </tr>
+    <tr>
+      <td>disable-scroll</td>
+      <td><b>boolean</b></td>
+      <td>false</td>
+      <td>Whether to disable scroll in slidebox</td>
+    </tr>
+    <tr>
+      <td>does-continue</td>
+      <td><b>boolean</b></td>
+      <td>false</td>
+      <td>Whether the slidebox auto-plays, in a slide-show fashion</td>
+    </tr>
+    <tr>
+      <td>slide-interval</td>
+      <td><b>integer</b></td>
+      <td>4000</td>
+      <td>If <code>does-continue</code> is true, sets the interval speed in milliseconds</td>
+    </tr>
+    <tr>
+      <td>on-slide-changed</td>
+      <td><b>function(index)</b></td>
+      <td></td>
+      <td>Called when a slide is changed, returns index parameter</td>
+    </tr>
+    <tr>
+      <td>active-slide</td>
+      <td><b>integer</b></td>
+      <td>0</td>
+      <td>Set the default slide number, at index</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Ionic-Angular Usage
 
 To use the slide box in your apps, use the following markup:


### PR DESCRIPTION
The Docs pages are missing some additional information that is available if you dig deep into the github repo. I added a table with the attributes of Slide Box, along with type, default, and description. If you accept this I can continue to update the docs with more pull requests.
