### PR TITLE
Replaced duplicate scrollbar-x with scrollbar-y

### DIFF
--- a/docs/api/directive/ionScroll/index.md
+++ b/docs/api/directive/ionScroll/index.md
@@ -58,7 +58,7 @@ Creates a scrollable container for all content inside.
     [on-refresh=""]
     [on-scroll=""]
     [scrollbar-x=""]
-    [scrollbar-x=""]>
+    [scrollbar-y=""]>
   ...
   </ion-scroll>
   ```
@@ -181,7 +181,7 @@ with <a href="/docs/api/service/$ionicScrollDelegate/"><code>$ionicScrollDelegat
     
     <tr>
       <td>
-        scrollbar-x
+        scrollbar-y
         
         <div><em>(optional)</em></div>
       </td>


### PR DESCRIPTION
The docs for the ion-scroll directive has scrollbar-x listed twice. I changed the second srollbar-x to scrollbar-y
