### PR TITLE
Removed unneeded step in installation.md

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -139,7 +139,6 @@ Before we start building our app, we should remove all the Cordova default code.
 ```bash
 $ rm www/index.html
 $ rm www/js/*
-$ rm www/css/app.css
 ```
 
 ## Cordova Config


### PR DESCRIPTION
In the "Clearing the defaults" part of the guide shown below, there is no need to remove the `www/css/app.css` file.
Since the project created by `$ ionic start hello` does not create it anymore.

![screen shot 2014-04-24 at 22 46 01](https://cloud.githubusercontent.com/assets/520376/2797794/f43a6f0a-cc3c-11e3-95d3-d38507bf4234.png)

The current folder structure is in the screenshot below; it shows that the css folder now just contains an empty "style.css" file after creating the project.
![screen shot 2014-04-24 at 22 39 52](https://cloud.githubusercontent.com/assets/520376/2797775/153b335c-cc3c-11e3-8746-c2fb9d8e5761.png)
