### PR TITLE
Update menuToggle documentation

### DIFF
--- a/docs/api/directive/menuToggle/index.md
+++ b/docs/api/directive/menuToggle/index.md
@@ -44,12 +44,12 @@ Toggle a side menu on the given side
 <h2 id="usage">Usage</h2>
   
 Below is an example of a link within a nav bar. Tapping this link would
-automatically open the given side menu
+automatically open the given side menu. Note that the menu-toggle attribute is actually "'left'", with single quotes inside of double-quotes.
 
 ```html
 <ion-view>
   <ion-nav-buttons side="left">
-   <button menu-toggle="left" class="button button-icon icon ion-navicon"></button>
+   <button menu-toggle="'left'" class="button button-icon icon ion-navicon"></button>
   </ion-nav-buttons>
  ...
 </ion-view>


### PR DESCRIPTION
Hi guys,

First, love your framework. I'm developing in it right now and am shocked at how quickly one can scaffold together an application. 

Second, it seems that the way menu-toggle works right now is that it runs a $scope.$eval() on the content of the menu-toggle attribute, so it's expecting an angular expression. Leaving it just with double-quotes works for the left side-menu, but adding menu-toggle="right" actually toggles the right-hand side menu as well. menu-toggle="'right'" works as expected, as does menu-toggle="'left'".

I wasn't sure how much detail to put into the docs about this, but it seems like you don't delve a whole lot into the "why" in your other documentation, just the "how", so I went a little minimalist on my changes. Let me know if you'd prefer that I change something.

Thanks again for your work!
Ian
