### PR TITLE
Fixed complicated grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@ body_css: "home"
 
     <h4>Native focused</h4>
     <p>
-      Ionic is modeled off of popular native mobile development SDKs, making it easy to understand for
+      Ionic is modeled on popular native mobile development SDKs, making it easy to understand for
       anyone that has built a native app for iOS or Android. Just drop it in your code to get going,
       and push through PhoneGap when it's ready. Develop once, deploy everywhere.
     </p>


### PR DESCRIPTION
On the home page, in the section under the header titled "Native focused", there is an occurrence of complicated grammar, which may confuse some readers. 

I suggest correcting <b>off of</b> to <b>on</b> in the following sentence (also see the image below). 

<b>Original Sentence</b>
 "Ionic is modelled <b>off of</b> popular native mobile development SDKs....."

<b>Correction</b>
 "Ionic is modelled <b>on</b> popular native mobile development SDKs....."

![screen shot 2014-05-29 at 12 18 40](https://cloud.githubusercontent.com/assets/4481885/3122374/75dbe5fe-e766-11e3-98d1-718dfbdd7075.png)
