### PR TITLE
Rename "AppCtrl" to "IntroCtrl"

### DIFF
--- a/tutorials/intro-tutorial/index.md
+++ b/tutorials/intro-tutorial/index.md
@@ -69,7 +69,7 @@ angular.module('myApp', ['ionic', 'ngRoute'])
   // updates a navigation bar
   $routeProvider.when('/', {
     templateUrl: 'intro.html',
-    controller: 'AppCtrl'
+    controller: 'IntroCtrl'
   });
 
   $routeProvider.when('/main', {
@@ -78,7 +78,7 @@ angular.module('myApp', ['ionic', 'ngRoute'])
   });
 
   // if none of the above routes are met, use this fallback
-  // which executes the 'AppCtrl' controller (controllers.js)
+  // which executes the 'IntroCtrl' controller (controllers.js)
   $routeProvider.otherwise({
     redirectTo: '/'
   });


### PR DESCRIPTION
seems like "AppCtrl" is from an earlier version. 
Doesn't make sense. Has to be "IntroCtrl".

https://github.com/driftyco/ionic-site/issues/169
