### PR TITLE
Make code snippet in guide a bit easier to copy-paste

### DIFF
--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -137,8 +137,15 @@ In order to trigger the Modal to open, we need a button in the main header bar a
         <i class="icon ion-compose"></i>
       </button>
     </ion-header-bar>
+    <ion-content>
+      <!-- our list and list items -->
+      <ion-list>
+        <ion-item ng-repeat="task in tasks">
+          {{task.title}}
+        </ion-item>
+      </ion-list>
+    </ion-content>
   </ion-side-menu-content>
-  <!-- ... -->
 ```
 
 And in our controller code:


### PR DESCRIPTION
Helps to avoid that people get stuck in the tutorial.

At the moment it seems like the ng-repeat section should be deleted. So the comment `<!-- ... --> should be one line above the closing tag, but it is much easier to just paste all the code.

This way it is easier to copy-paste without the need to think about which exact line has to be put where.

This code...

```
<!-- Center content -->
<ion-side-menu-content>
  <ion-header-bar class=bar-dark">
    <h1 class="title">Todo</h1>
   <!-- NEW CODE GOES HERE -->
  </ion-header-bar>
  <ion-content>
    <!-- our list and list items -->
    <ion-list>
      <ion-item ng-repeat="task in tasks">
        {{task.title}}
      </ion-item>
    </ion-list>
  </ion-content>
</ion-side-menu-content>
```

...becomes this code:

```
  <!-- Center content -->
  <ion-side-menu-content>
    <ion-header-bar class="bar-dark">
      <h1 class="title">Todo</h1>
      <!-- New Task button-->
      <button class="button button-icon" ng-click="newTask()">
        <i class="icon ion-compose"></i>
      </button>
    </ion-header-bar>
   <!-- WOOOPS, WHERE HAS THE NG-REPEAT GONE? -->
  </ion-side-menu-content>
  <!-- ... -->
```

Uppercase comments are from me to make it clear where to look...
