### PR TITLE
Update to installation.md for Windows users

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -63,14 +63,14 @@ Next, create an environment variable for <code>JAVA_HOME</code> pointing to the 
 <p>
 To install Ant, download a zip from <a href="http://ant.apache.org/bindownload.cgi">here</a>, extract it, move the first folder in the zip to a safe place, and update your PATH to include the <code>bin</code> folder in that folder. For example, if you moved the Ant folder to <code>c:/</code>, you'd want to add this to your PATH: <code>C:\apache-ant-1.9.2\bin</code>.
 </p>
-
-### Android SDK ###
-
-<p>Installing the <a href="http://developer.android.com/sdk/index.html">Android SDK</a> is also necessary. The Android SDK provides you the API libraries and developer tools necessary to build, test, and debug apps for Android.</p>
-
 <p>
-Cordova requires the ANDROID_HOME environment variable to be set. This should point to the <code>[ANDROID_SDK_DIR]\sdk</code> directory (for example <code>c:\android\sdk</code>).</p>
-
+<strong>Android SDK</strong>
+</p>
+<p>Installing the <a href="http://developer.android.com/sdk/index.html">Android SDK</a> is also necessary. The Android SDK provides you the API libraries and developer tools necessary to build, test, and debug apps for Android.
+</p>
+<p>
+Cordova requires the ANDROID_HOME environment variable to be set. This should point to the <code>[ANDROID_SDK_DIR]\sdk</code> directory (for example <code>c:\android\sdk</code>).
+</p>
 <p>
 Next, update your PATH to include the <code>tools/</code> and <code>platform-tools/</code> folder in that folder. So, using ANDROID_HOME, you would add both <code>%ANDROID_HOME%\tools</code> and <code>%ANDROID_HOME%\platform-tools</code>.
 </p>


### PR DESCRIPTION
An overhaul of the section "Windows note on Java, Ant and Android". Fixed link for Ant. Reorganized under headings.  Included note about installing Android SDK and PATH variables for tools and platform-tools.
