### PR TITLE
footer: Fix capitalization of "GitHub"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
     &#183; <a href="http://forum.ionicframework.com/">Forum</a>
     &#183; <a href="/contribute/">Contribute</a>
     &#183; <a href="http://ionicons.com/">Ionicons</a>
-    &#183; <a href="https://github.com/driftyco/ionic">Github</a>
+    &#183; <a href="https://github.com/driftyco/ionic">GitHub</a>
     &#183; <a href="/contribute/#issues">Issues</a>
     &#183; <a href="/jobs/">Jobs</a>
   </nav>


### PR DESCRIPTION
Just a tiny change.
