### PR TITLE
AngularJS anchor link doesn't work in the docs overview

### DIFF
--- a/_layouts/docs_overview.html
+++ b/_layouts/docs_overview.html
@@ -29,7 +29,6 @@
               <li><a href="/docs/overview/#starter">Starter Project</a></li>
               <li><a href="/docs/overview/#whats-included">What's included</a></li>
               <li><a href="/docs/overview/#css-sass">CSS/SASS</a></li>
-              <li><a href="/docs/overview/#angularjs">AngularJS</a></li>
               <li><a href="/docs/overview/#phonegap">Phonegap</a></li>
               <li><a href="/docs/overview/#browser-support">Browser Support</a></li>
               <li><a href="/docs/overview/#license">Licensing</a></li>


### PR DESCRIPTION
See http://ionicframework.com/docs/overview and click AngularJS in the left hand navigation section titled Overview.
