### PR TITLE
Updated index.html

### DIFF
--- a/docs/1.0.0-beta.10/api/directive/collectionRepeat/index.html
+++ b/docs/1.0.0-beta.10/api/directive/collectionRepeat/index.html
@@ -862,7 +862,7 @@ positioned).</p>
       {{item}}
     <span class="nt">&lt;/div&gt;</span>
   <span class="nt">&lt;/div&gt;</span>
-<span class="nt">&lt;/div&gt;</span>
+<span class="nt">&lt;/ion-content&gt;</span>
 </code></pre></div><div class="highlight"><pre><code class="js language-js" data-lang="js"><span class="kd">function</span> <span class="nx">ContentCtrl</span><span class="p">(</span><span class="nx">$scope</span><span class="p">)</span> <span class="p">{</span>
   <span class="nx">$scope</span><span class="p">.</span><span class="nx">items</span> <span class="o">=</span> <span class="p">[];</span>
   <span class="k">for</span> <span class="p">(</span><span class="kd">var</span> <span class="nx">i</span> <span class="o">=</span> <span class="mi">0</span><span class="p">;</span> <span class="nx">i</span> <span class="o">&lt;</span> <span class="mi">1000</span><span class="p">;</span> <span class="nx">i</span><span class="o">++</span><span class="p">)</span> <span class="p">{</span>


### PR DESCRIPTION
Example code for collection-repeat has wrong markup on line 865. 

It ends with div tag and It was supposed to be ion-content tag.
