### PR TITLE
Fix bug with .snap-bar not showing in non webkit browsers

### DIFF
--- a/_layouts/full.html
+++ b/_layouts/full.html
@@ -52,7 +52,7 @@
       .snap-bar.active {
         
         -webkit-transform: translate(0, 0);
-        transform: translate(0, 0x);
+        transform: translate(0, 0);
         
         margin-top: 0;
       }


### PR DESCRIPTION
The 'x' causes the transform to be ignored in Firefox (and I assume other non webkit browsers) so the .snap-bar element remains hidden after the body content has animated down.
