### PR TITLE
Fixed typo

### DIFF
--- a/docs/ionic-cli-faq/index.html
+++ b/docs/ionic-cli-faq/index.html
@@ -92,7 +92,7 @@ export PATH=/usr/local/bin:$PATH
         <p>Well this is because you need to install a utility package called ios-sim. This package allows you to access the iOS simulator from the command line. This can be installed with a simple <code>npm install</code>.</p>
       {% highlight bash %}$ sudo npm install -g ios-sim
 {% endhighlight %}
-        <p>With this installed, you’ll be able to emulate to the iso-simulator.</p>
+        <p>With this installed, you’ll be able to emulate to the iOS-simulator.</p>
         <hr>
 
 </section>


### PR DESCRIPTION
Fixed a typo: iso-simulator is now iOS-simulator
