### PR TITLE
Change active tab in Tab CSS demo

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -277,7 +277,12 @@ var ionicSite = (function(){
         window.rAF(function(){
           $('#' + exampleId)
             .addClass('active-preview')
-            .find('a').click(function(){
+            .find('a').click(function(e){
+              // Activates tabs in tab CSS demo.
+              if ($(this).hasClass('tab-item')) {
+                $(this).siblings('.tab-item').removeClass('active');
+                $(this).addClass('active');
+              }
               return false;
             });
         });


### PR DESCRIPTION
Changes the active tab in the demo at http://ionicframework.com/docs/components/#striped-style-tabs

Currently they don't activate in the demo, which as a Firefox user I actually took to me they didn't work in Firefox. When I tried in Safari I realized they just weren't set up to activate. The code I added hooks into the `return false;` on all the `<a>` tags in the CSS demo section to activate tabs, if the link has the class `tab-item`.

You can now activate tabs as pictured:
![screen shot 2014-10-29 at 23 20 03](https://cloud.githubusercontent.com/assets/90871/4838115/abfb8c7a-5fe3-11e4-9a3f-a12fc60cdd66.png)
