### PR TITLE
typo fixes to docs/ionic-cli-faq/index.html

### DIFF
--- a/docs/ionic-cli-faq/index.html
+++ b/docs/ionic-cli-faq/index.html
@@ -12,7 +12,7 @@ search_sections: true
 
 <p>When working with Cordova and Ionic, Node is going to be your best friend. Specifically working with Node and the Command Line. Yet getting things set up often seems to be a challenge, especially when it comes to setting up things cross platform (Mac,
   Windows, Linux).</p>
-<p>Below are a few issues that are not necessarily an Ionic Framework issue, but common pitfalls seen related to Cordova, Node, NPM,Android:</p>
+<p>Below are a few issues that are not necessarily an Ionic Framework issue, but common pitfalls seen related to Cordova, Node, NPM, Android:</p>
 
 <section class="docs-section active" id="android-sdk">
 
@@ -53,7 +53,7 @@ export PATH=/usr/local/bin:$PATH
 <section class="docs-section" id="genymotion">
 
   <h3 class="title"><a href="#genymotion">Genymotion</a></h3>
-        <p>This helpful tip cannot be stressed enough! Even when working natively, the android emulator is a pain. It’s slow to boot, becomes unresponsive and locks up easily. Thankfully <a href="http://www.genymotion.com/">Genymotion</a> is a great replacement. It uses a virtual machine to emulate android devices and does it perfectly. Once thing to remember, if you want to deploy to a genymotion device, your computer will treat it as an actual connect machine. So instead of running</p>
+        <p>This helpful tip cannot be stressed enough! Even when working natively, the Android emulator is a pain. It’s slow to boot, becomes unresponsive and locks up easily. Thankfully <a href="http://www.genymotion.com/">Genymotion</a> is a great replacement. It uses a virtual machine to emulate android devices and does it perfectly. Once thing to remember, if you want to deploy to a genymotion device, your computer will treat it as an actual connect machine. So instead of running</p>
         {% highlight bash %}
         $ ionic emulate android
         {% endhighlight %}
@@ -72,7 +72,7 @@ export PATH=/usr/local/bin:$PATH
 
   <h3 class="title"><a href="#cli-commands">Unreleased Node Versions</a></h3>
 
-  <p>If you’re a node developer, you’re probably using the latest and greatest release of node on your system. While this is great for testing apps with node, Cordova and Ionic need to have some stability. When doing anything with the command line and ionic, always use a stable release of Ionic.</p>
+  <p>If you’re a node developer, you’re probably using the latest and greatest release of node on your system. While this is great for testing apps with node, Cordova and Ionic need to have some stability. When doing anything with the command line and Ionic, always use a stable release of node.</p>
 
 <hr>
 
@@ -132,7 +132,7 @@ export PATH=/usr/local/bin:$PATH
 <section class="docs-section" id="cordova-directory">
 
   <h3 class="title"><a href="#cordova-directory">Cordova Directory</a></h3>
-   <p>This one is pretty extreme and cause a lot of frustration. You try to use any of the Cordova/Ionic commands and get this error.</p>
+   <p>This one is pretty extreme and can cause a lot of frustration. You try to use any of the Cordova/Ionic commands and get this error.</p>
         {% highlight bash %}
           Current Working Directory is not Cordova-based project
 {% endhighlight %}


### PR DESCRIPTION
Mostly minor typo fixes.

The one major typo fix is at the end of line 75.
