### PR TITLE
anchor #support for support forms row

### DIFF
--- a/server/pages/support.html
+++ b/server/pages/support.html
@@ -57,7 +57,7 @@
 
   <section class="container">
     <hgroup>
-      <h2>Business and Customer Support</h2>
+      <h2 id="support">Business and Customer Support</h2>
       <p>
         Run into a problem? Get in touch, we’re here to help. This requires an
         Ionic account.


### PR DESCRIPTION
Linking to http://ionicframework.com/support in the forum currently seems like a bad joke to the "receiver" as the first thing they see is actually a link back to the community forum. Having this anchor fixes this by enabling linking to http://ionicframework.com/support#support.