### PR TITLE
fix(tutorial): navigation bar link broken

### DIFF
--- a/content/docs/intro/tutorial/adding-pages/index.md
+++ b/content/docs/intro/tutorial/adding-pages/index.md
@@ -107,7 +107,7 @@ All pages have both a class, and an associated template that's being compiled as
 {% endraw %}
 ```
 
-The `<ion-navbar>` is a template for the [navigation bar](/docs//api/components/navbar/Navbar/) on this page. As we navigate to this page, the button and title of the navigation bar transition in as part of the page transition.
+The `<ion-navbar>` is a template for the [navigation bar](/docs/api/components/toolbar/Navbar/) on this page. As we navigate to this page, the button and title of the navigation bar transition in as part of the page transition.
 
 The rest of the template is standard Ionic code that sets up our content area and prints our welcome message.
 


### PR DESCRIPTION
Fix navigation bar URL so it no longer 404s and instead links to the navigation bar page.