### PR TITLE
Add demo source link to component API docs

### DIFF
--- a/assets/scss/_general.scss
+++ b/assets/scss/_general.scss
@@ -192,6 +192,7 @@ a.footer-link {
   > a {
     position: relative;
     top: -25px;
+    font-size: 15px;
 
     &, &:hover, &:active, &:focus {
       text-decoration: none;

--- a/assets/scss/_general.scss
+++ b/assets/scss/_general.scss
@@ -188,6 +188,15 @@ a.footer-link {
     position: fixed;
     top: 0;
   }
+
+  > a {
+    position: relative;
+    top: -25px;
+
+    &, &:hover, &:active, &:focus {
+      text-decoration: none;
+    }
+  }
 }
 
 .platform-preview .platform-toggle, .docs-container .sass-platform-toggle {

--- a/content/_layouts/fluid/docs_base.html
+++ b/content/_layouts/fluid/docs_base.html
@@ -71,6 +71,9 @@ layout: fluid/default
               frameborder="0">
       </iframe>
     </div>
+    {% if page.preview_device_url %}
+      <a href="https://github.com/ionic-team/ionic/tree/master/{{ page.preview_device_url | replace: '/docs/', '' | replace: '/www/', '' }}">Demo source</a>
+    {% endif %}
   </aside>
   {% endif %}
   <main>


### PR DESCRIPTION
Resolves #1179 

When reviewing this, make sure you're okay with the string replacement in the template to re-format the `preview_device_url` into a path on GitHub.  It would be nice to do this differently but that would involve changing a lot of references in the Ionic source.