### PR TITLE
Add style for doc section heading as anchor

### DIFF
--- a/assets/scss/_general.scss
+++ b/assets/scss/_general.scss
@@ -411,11 +411,15 @@ ul.docs-example {
   }
 }
 
-.docs-container h3 a:not([role='button']) {
-  color: #26292e !important;
+.docs-container {
+  h2, h3 {
+    a:not([role='button']) {
+      color: #26292e !important;
 
-  &:hover {
-    color: #26292e !important;
+      &:hover {
+        color: #26292e !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This adds a style required for making doc section headings clickable as anchors, which is being worked on in https://github.com/ionic-team/ionic/pull/12386.  I'm making this a pull so they can be easily merged at the same time.