### PR TITLE
Bundle install automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ gulp watch uses LiveReload. You may have to up your max file limit with the foll
 
 ## Local Build
 
-1. Install jekyll: `bundle install`
-2. Run `npm install`
+1. Run `npm install`
+2. Install gems (Jekyll and kramdown): `npm run bundle-install`
+
+    > This will re-construct your `Gemfile.lock` for the specific platform you are developing on and exclude it from Git.  If you need to make a change to the `Gemfile`, or are updating gems, you will need to remove the `Gemfile.lock` from `.git/info/exclude`.
+
 3. Run `gulp watch` (after the first run, this is the only step needed)
 
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Ionic Framework main site - IonicFramework.com",
   "main": "Gulpfile.js",
   "scripts": {
+    "bundle-install": "echo Gemfile.lock > .git/info/exclude && rm -f Gemfile.lock && bundle exec bundle install && git update-index --assume-unchanged Gemfile.lock",
     "heroku-postbuild": "gulp build.clean && gulp slug.prep"
   },
   "engines": {


### PR DESCRIPTION
Resolves #1203 

This adds a new command for developers to set up the site with a new `Gemfile.lock` for their environment and exclude future changes to the lockfile for cross-platform development.

@perrygovier Would you want to test this on your machine too?