### PR TITLE
Install http-loader 0.1.0 instead of the latest

### DIFF
--- a/content/docs/developer-resources/ng2-translate/index.md
+++ b/content/docs/developer-resources/ng2-translate/index.md
@@ -10,7 +10,7 @@ header_sub_title: Ionic Resources
 
 ### Installing
 
-To install ngx-translate run `npm install @ngx-translate/core @ngx-translate/http-loader --save`.
+To install ngx-translate run `npm install @ngx-translate/core @ngx-translate/http-loader@0.1.0 --save`.
 
 ### Bootstrapping
 


### PR DESCRIPTION
As per the official [ngx-translate documentation](https://github.com/ngx-translate/core/blob/master/README.md) :
"NB: if you're still on Angular <4.3, please use Http from @angular/http with http-loader@0.1.0."

So untill we upgrade Ionic to angular 4.3, the documentation should instruct to use version 0.1.0 of the http loader.