### PR TITLE
Fix broken links

### DIFF
--- a/content/docs/developer-resources/what-is/index.md
+++ b/content/docs/developer-resources/what-is/index.md
@@ -84,7 +84,7 @@ header_sub_title: Ionic Resources
 
   <section id="genymotion">
     <h3><a href="#genymotion">Genymotion</a></h3>
-    <p>Genymotion is a third-party Android emulator. It is extremely fast, and is useful for quickly testing your app on Android. Check out our <a href="/docs//resources/developer-tips/#using-genymotion-android">resource section</a> on Genymotion for more info.</p>
+    <p>Genymotion is a third-party Android emulator. It is extremely fast, and is useful for quickly testing your app on Android. Check out our <a href="/docs/resources/developer-tips/#using-genymotion-android">resource section</a> on Genymotion for more info.</p>
   </section>
 
   <section id="git">

--- a/content/docs/intro/tutorial/index.md
+++ b/content/docs/intro/tutorial/index.md
@@ -23,7 +23,7 @@ Now that you have [Ionic and its dependencies installed](../installation), you c
 
 ### Starting a New Ionic App
 
-Starting a new app is easy! From your [command line](/docs//resources/what-is/#cli), run this command:
+Starting a new app is easy! From your [command line](/docs/resources/what-is/#cli), run this command:
 
 ```bash
 $ ionic start MyIonicProject tutorial

--- a/content/docs/intro/tutorial/project-structure/index.md
+++ b/content/docs/intro/tutorial/project-structure/index.md
@@ -42,7 +42,7 @@ And the following scripts near the bottom:
 
 <h3 class="file-title">./src/</h3>
 
-Inside of the `src` directory we find our raw, uncompiled code. This is where most of the work for an Ionic app will take place. When we run `ionic serve`, our code inside of `src/` is [transpiled](/docs//resources/what-is/#transpiler) into the correct Javascript version that the browser understands (currently, [ES5](/docs//resources/what-is/#es5)). That means we can work at a higher level using TypeScript, but compile down to the older form of Javascript the browser needs.
+Inside of the `src` directory we find our raw, uncompiled code. This is where most of the work for an Ionic app will take place. When we run `ionic serve`, our code inside of `src/` is [transpiled](/docs/resources/what-is/#transpiler) into the correct Javascript version that the browser understands (currently, [ES5](/docs/resources/what-is/#es5)). That means we can work at a higher level using TypeScript, but compile down to the older form of Javascript the browser needs.
 
 `src/app/app.module.ts` is the entry point for our app.
 

--- a/content/docs/troubleshooting/index.md
+++ b/content/docs/troubleshooting/index.md
@@ -42,7 +42,7 @@ For windows, run this from an admin command prompt.
 
 ## Adding third party libs
 
-See our resources page on [Adding Third Party Libs](/docs//resources/third-party-libs).
+See our resources page on [Adding Third Party Libs](/docs/resources/third-party-libs).
 
 
 ## Blank App

--- a/content/docs/v1/overview/index.html
+++ b/content/docs/v1/overview/index.html
@@ -140,7 +140,7 @@ $ ionic start myproject --type ionic1
 
   <h3>Ionic 2</h3>
 
-  <p>Ionic 2 is focused on building both native/hybrid apps through Cordova, as well as adding the ability for <a href="/docs//resources/progressive-web-apps/">Progressive Web Apps</a> and <a href="http://electron.atom.io">Electron</a>  .</p>
+  <p>Ionic 2 is focused on building both native/hybrid apps through Cordova, as well as adding the ability for <a href="/docs/resources/progressive-web-apps/">Progressive Web Apps</a> and <a href="http://electron.atom.io">Electron</a>  .</p>
   <p>The following OSs and browsers are supported: </p>
 
   <ul>


### PR DESCRIPTION
`/docs//resources/` can't be redirect to `/docs/developer-resources/`. Users will get an 404 error when they click on these link.

In order to solve this issue, we have to change all `/docs//resources/` to `/docs/resources/`