### PR TITLE
Fix(URLs): component docs tabs-badges

### DIFF
--- a/content/_includes/fluid/component-docs/tabs.html
+++ b/content/_includes/fluid/component-docs/tabs.html
@@ -207,10 +207,10 @@ export class TabsTextPage {
 <h3 class="section-nav" id="tabs-badges">Badges</h3>
 <p>
   <nobr class="component-doc-demo">
-    <a target="_blank" class="btn component-doc-demo-mobile" href="/dist/preview-app/www/?production=true#/nav/n4/tab-badge">
+    <a target="_blank" class="btn component-doc-demo-mobile" href="/dist/preview-app/www/?production=true#/nav/n4/tab-badges">
       Demo
     </a>
-    <a target="_blank" href="https://github.com/ionic-team/ionic-preview-app/tree/master/src/pages/tabs/icon-text">
+    <a target="_blank" href="https://github.com/ionic-team/ionic-preview-app/tree/master/src/pages/tabs/badges">
       Demo Source
     </a>
   </nobr>


### PR DESCRIPTION
Typos in the links to the tab badges demo & demo source