### PR TITLE
Update lists.html

### DIFF
--- a/content/_includes/fluid/component-docs/lists.html
+++ b/content/_includes/fluid/component-docs/lists.html
@@ -279,12 +279,12 @@ Item thumbnails showcase an image that takes up the entire height of an item. To
 ```html
 <ion-list>
   <ion-item>
-    <ion-thumbnail item-start>
+    <ion-thumbnail item-left>
       <img src="img/thumbnail-totoro.png">
     </ion-thumbnail>
     <h2>My Neighbor Totoro</h2>
     <p>Hayao Miyazaki • 1988</p>
-    <button ion-button clear item-end>View</button>
+    <button ion-button clear item-right>View</button>
   </ion-item>
 </ion-list>
 ```


### PR DESCRIPTION
The 'Basic Usage' example of Thumbnail Lists shows an incorrect way of positioning items within the list.
It should be 'item-left' rather than 'item-start'
Also, 'item-right' rather than 'item-end'