### PR TITLE
Add docs regarding zoom.

### DIFF
--- a/content/docs/3.9.2/api/components/slides/Slides/index.md
+++ b/content/docs/3.9.2/api/components/slides/Slides/index.md
@@ -946,7 +946,7 @@ slider.</p>
     <tr>
       <td>zoom</td>
       <td><code>boolean</code></td>
-      <td><p> If true, enables zooming functionality.</p>
+      <td><p> If true, enables zooming functionality. You might need to wrap the ion-slide with a container div with the class `.swiper-zoom-container` to get zoom working.</p>
 </td>
     </tr>
     


### PR DESCRIPTION
It took me more than an hour to figure out why zoom was not working for my slides. 
Finally found issue https://github.com/ionic-team/ionic/issues/12861 that explained that I needed a div around my image before zoom would work. 

The wording might not be perfect, but I would strongly recommend at least some indication of the class being necessary for zoom to work.

My code before: 
```
<ion-slides pager zoom>
    <ion-slide *ngFor="let pics of pictures" style="background-color: black;">
        <img src="/assets/imgs/logo.png"/>
    </ion-slide>
  </ion-slides>
```

My code after:
```
<ion-slides pager zoom>
    <ion-slide *ngFor="let pics of pictures" style="background-color: black;">
      <div class="swiper-zoom-container">
        <img src="/assets/imgs/logo.png"/>
      </div>
    </ion-slide>
  </ion-slides>
```