### PR TITLE
Need to change config.xml file

### DIFF
--- a/content/docs/intro/deploying/index-modified.md
+++ b/content/docs/intro/deploying/index-modified.md
@@ -31,6 +31,12 @@ This will produce a debug build of your app, both in terms of Android and Ionic'
 
 Enabling USB debugging and Developer Mode can vary between devices, but is easy to look up with a Google search. You can also check out [Enabling On-device Developer Options](https://developer.android.com/studio/run/device.html#developer-device-options) in the Android docs.
 
+
+### Change you config file
+
+Before you build the release apk, go to your config.xml file and change the package id from "io.starter.ionic" to "io.----yourprojectname--.ionic" because playstore won't let you upload the APK because of same package name which is already present in it.
+
+
 ### Production Builds
 
 To run or build your app for production, run


### PR DESCRIPTION
The users usually wont even know they have to change the package name before publishing and I just did the same mistake. The playstore already has io.ionic.starter package name with some other APK, hence I had to resign my APK again with config.xml changes. Its better to specify this before the production build content.