### PR TITLE
Fix "broswer" typo

### DIFF
--- a/content/docs/intro/browser-support/index.md
+++ b/content/docs/intro/browser-support/index.md
@@ -22,7 +22,7 @@ Mobile OSs
 * Android 4.4+
   * Support can be pushed back to 4.1 if Crosswalk is used with Cordova
 
-Broswer
+Browser
 
 * Safari
 * Chrome


### PR DESCRIPTION
There was a typo where https://ionicframework.com/docs/intro/browser-support/ displayed "broswer." This updates it to say "browser."

![image](https://user-images.githubusercontent.com/4126319/37795658-82ce3026-2deb-11e8-8128-1f72983c4b74.png)
