### PR TITLE
Update index.md

### DIFF
--- a/content/docs/intro/deploying/index.md
+++ b/content/docs/intro/deploying/index.md
@@ -58,7 +58,7 @@ __Note__: Make sure to save this file somewhere safe, if you lose it you won’t
 To sign the unsigned APK, run the jarsigner tool which is also included in the JDK:
 
 ```bash
-jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.jks android-release-unsigned.apk my-alias
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.jks app-release-unsigned.apk my-alias
 ```
 
 This signs the APK in place. Finally, we need to run the zip align tool to optimize the APK. The zipalign tool can be found in `/path/to/Android/sdk/build-tools/VERSION/zipalign`. For example, on OS X with Android Studio installed, zipalign is in `~/Library/Android/sdk/build-tools/VERSION/zipalign`:


### PR DESCRIPTION
changed android-release-unsigned.apk to app-release-unsigned.apk because build command builds apk file with the name of app-release-unsigned. For the beginner who doesnot know how to sign apk, it is difficult to figure this out .