### PR TITLE
Do not advise to run npm as sudo

### DIFF
--- a/content/docs/intro/installation/index.md
+++ b/content/docs/intro/installation/index.md
@@ -36,7 +36,7 @@ $ npm install -g ionic cordova
 ```
 
 > Note: The `-g` means this is a global install, so for Window's you will need
-> to open an Admin command prompt. For Mac/Linux, you'll need to run the command
+> to open an Admin command prompt. For Mac/Linux, you might need to run the command
 > with `sudo`.
 
 Once that's done, create your first Ionic app:


### PR DESCRIPTION
If the permissions for `npm` are set up correctly, there is no need to prefix the command with `sudo`. The docs should not advise to run commands as `sudo` if not necessary.