### PR TITLE
close img tags in examples

### DIFF
--- a/content/_includes/fluid/component-docs/cards.html
+++ b/content/_includes/fluid/component-docs/cards.html
@@ -258,13 +258,13 @@ It's often necessary to create social cards within an application. Using a combi
 
   <ion-item>
     <ion-avatar item-start>
-      <img src="img/marty-avatar.png">
+      <img src="img/marty-avatar.png"/>
     </ion-avatar>
     <h2>Marty McFly</h2>
     <p>November 5, 1955</p>
   </ion-item>
 
-  <img src="img/advance-card-bttf.png">
+  <img src="img/advance-card-bttf.png"/>
 
   <ion-card-content>
     <p>Wait a minute. Wait a minute, Doc. Uhhh... Are you telling me that you built a time machine... out of a DeLorean?! Whoa. This is heavy.</p>


### PR DESCRIPTION
With the img tag not closed, the example does not compile.