### PR TITLE
Clarificate Deploying requirements

### DIFF
--- a/content/docs/intro/deploying/index.md
+++ b/content/docs/intro/deploying/index.md
@@ -20,8 +20,8 @@ Deploying to an Android device is a fairly straightforward process. If you have 
 ### Requirements
 
 - [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html)
-- [Android Studio](https://developer.android.com/studio/index.html)
-- Updated Android SDK tools, platform and component dependencies. Available through Android Studio's [SDK Manager](https://developer.android.com/studio/intro/update.html)
+- [Android Studio or Android Command Line Tools](https://developer.android.com/studio/index.html)
+- Updated Android SDK tools, platform and component dependencies. Available through Android Studio's [SDK Manager](https://developer.android.com/studio/intro/update.html) or through Android's [`sdkmanager`](https://developer.android.com/studio/command-line/sdkmanager) from the command line tools.
 
 ### Running Your App
 


### PR DESCRIPTION
The requirement of having Android Studio installed is optional if we take into account that we can also use Android SDK's command line tools. You can install, update, and uninstall packages with one of those tools (`sdkmanager`). This is also offered as an option in their site, and the download has a smaller file size.