### PR TITLE
Fix typo in Studio page

### DIFF
--- a/server/pages/products/studio.html
+++ b/server/pages/products/studio.html
@@ -118,7 +118,7 @@
         <li class="no-docs">
           <strong>No Docs Required</strong>
           <p>
-            With Ionic’s components at your fingertips, ther’s no need to dig 
+            With Ionic’s components at your fingertips, there’s no need to dig 
             through pages of documentation to learn Ionic.
           </p>
         </li>


### PR DESCRIPTION
Hi! 👋

I saw a typo in the new Ionic Studio landing page so I fixed it, I hope you don't mind 🙂

Also, the column paragraphs at the "Full-featured IDE" and "Superpowers for creating" sections are almost the same and I have the feeling it may be unintentional :wink:

Best,
Rodrigo