### PR TITLE
Updated Paul Halliday's description URL

### DIFF
--- a/server/pages/community.html
+++ b/server/pages/community.html
@@ -301,7 +301,7 @@
         <strong>Paul Halliday</strong>
         <p>
           Author. Developer Advocate. Instructor at <a target="_blank"
-          href="https://paulhalliday.io/">paulhalliday.io</a>.
+          href="https://developer.school/">developer.school</a>.
         </p>
         <a href="https://twitter.com/paulhalliday_io" class="twitter" target="_blank">
           <ion-icon name="logo-twitter"></ion-icon>


### PR DESCRIPTION
Removed https://paulhalliday.io for https://developer.school.