### PR TITLE
Fix text padding issue on /react page

### DIFF
--- a/assets/scss/pages/react.scss
+++ b/assets/scss/pages/react.scss
@@ -364,6 +364,7 @@
     img {
       width: 100%;
       max-width: 308px;
+      margin-bottom: 28px;
     }
   }
 


### PR DESCRIPTION
HI

Context:
https://ionicframework.com/react#samples

The features cards is missing a margin bottom. 


| Before | After |
| --- | --- |
| <img width="1131" alt="Capture d’écran 2020-10-05 à 15 30 22" src="https://user-images.githubusercontent.com/9492287/95086398-bf9cbc00-0720-11eb-9b78-b8771d592966.png"> | <img width="1131" alt="Capture d’écran 2020-10-05 à 15 25 48" src="https://user-images.githubusercontent.com/9492287/95086407-c1ff1600-0720-11eb-81f3-488b67c89c61.png"> |

I saw a class `.feature .image` unused with a margin bottom set to 28px and I added it directly to the img tag.