### PR TITLE
Replaces javebratt.com links to jsmobiledev.com

### DIFF
--- a/server/pages/community.html
+++ b/server/pages/community.html
@@ -265,7 +265,7 @@
         <strong>Jorge Vergara</strong>
         <p>
           Mobile Dev. Author of <a target="_blank"
-          href="https://javebratt.com/ionic-firebase-book/">Building Firebase
+          href="https://jsmobiledev.com/firebase-free-course">Building Firebase
           powered Ionic apps</a>.
         </p>
         <a href="https://twitter.com/javebratt" class="twitter" target="_blank">
@@ -480,11 +480,11 @@
           </li>
           <li>
             <a target="_blank"
-               href="https://javebratt.com/ionic-firebase-tutorial-intro/">
+               href="https://jsmobiledev.com/firebase-free-course">
               <strong>
                 Building Your First Firebase Powered Ionic Framework App
               </strong>
-              <p>A 7 post series that will teach you how to bui...</p>
+              <p>A 5 post series that will teach you how to bui...</p>
               <span>Jorge Vergara &nbsp; July 2, 2018</span>
             </a>
           </li>
@@ -702,9 +702,9 @@
           </a>
         </li>
         <li class="">
-          <a target="_blank" href="https://javebratt.com/ionic-firebase-book/">
-            <h4>Book</h4>
-            <h3>Building Firebase Powered Ionic Apps</h3>
+          <a target="_blank" href="https://jsmobiledev.com/firebase-free-course">
+            <h4>Course</h4>
+            <h3>Get started building apps with Ionic and Firebase</h3>
             <p>Everything you need to build Ionic apps using Firebase.</p>
           </a>
         </li>

--- a/server/pages/contributors.html
+++ b/server/pages/contributors.html
@@ -76,7 +76,7 @@
     </div>
     <div class="quotes__quote verganara">
       <div class="quotes__content">
-        <a href="https://javebratt.com/">
+        <a href="https://jsmobiledev.com/">
           <div class="quotes__avatar verganara" title="Jorge Vergara"></div>
           <blockquote>
             <p>&ldquo;During 2017/18 I've had my articles on the Ionic blog and shared on their newsletter. The exposure led to over 1,500 new subscribers and over $5,000 in book sales.&rdquo;</p>

--- a/server/pages/pwa/index.html
+++ b/server/pages/pwa/index.html
@@ -241,7 +241,7 @@
           </a>
         </li>
         <li>
-          <a href="https://javebratt.com/pwa-faq/" target="_blank">
+          <a href="https://jsmobiledev.com/article/pwa-faq" target="_blank">
             <article class="card">
               <img class="card__image"  loading="lazy" width="520" height="340" src="/img/pwa/dive-in-faq.png"/>
               <div class="card__content">


### PR DESCRIPTION
Hey team,

A few months ago I changed my domain from javebratt.com to jsmobiledev.com, so I'm going through the site updating the links to make sure they point to the appropriate places.

I have http redirections set up, so there's no rush on this PR 😁