### PR TITLE
Vue landing page: remove tracking event

### DIFF
--- a/server/pages/vue.html
+++ b/server/pages/vue.html
@@ -598,9 +598,5 @@ ionic start --type=vue
   </div>
   `).insertBefore("#tweet-share")
   );
-
-  // Hubspot event tracking
-  var _hsq = (window._hsq = window._hsq || []);
-  _hsq.push(["trackEvent", { id: "Viewed_Vue_Landing" }]);
 </script>
 {% endblock %}


### PR DESCRIPTION
Turns out we don't need a dedicated HS event - we're using UTMs so that should be sufficient.