### PR TITLE
Vue landing updates: change CTA and add youtube embed

### DIFF
--- a/server/pages/vue.html
+++ b/server/pages/vue.html
@@ -30,7 +30,7 @@
       </h1>
       <div class="cta-row">
         <a
-          href="https://ionicframework.com/start#vue"
+          href="https://ionicframework.com/signup"
           target="_blank"
           id="ionic-react-get-started-cta"
           class="primary-btn"
@@ -38,13 +38,14 @@
           Start an app
           <span class="arrow"> -></span>
         </a>
-        <a href="#components" id="ionic-react-live-demo-cta" class="secondary-btn">
-          Live Demo
-          <span class="arrow"> -></span>
-        </a>
       </div>
     </hgroup>
   </header>
+
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/o-mgzWKfMaE?start=20" 
+    title="YouTube video player" frameborder="0" 
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+  </iframe>
 </div>
 
 <nav id="sticky-bar">

--- a/server/pages/vue.html
+++ b/server/pages/vue.html
@@ -39,13 +39,18 @@
           <span class="arrow"> -></span>
         </a>
       </div>
+      <div class="cta-row">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/o-mgzWKfMaE?start=20" 
+          title="YouTube video player" frameborder="0" 
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+        </iframe>
+      </div>
     </hgroup>
+
+    
   </header>
 
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/o-mgzWKfMaE?start=20" 
-    title="YouTube video player" frameborder="0" 
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-  </iframe>
+  
 </div>
 
 <nav id="sticky-bar">

--- a/server/pages/vue.html
+++ b/server/pages/vue.html
@@ -30,7 +30,7 @@
       </h1>
       <div class="cta-row">
         <a
-          href="https://ionicframework.com/signup"
+          href="https://ionicframework.com/signup?source=ionic_io"
           target="_blank"
           id="ionic-react-get-started-cta"
           class="primary-btn"


### PR DESCRIPTION
- Point "Create an app" button to /signup page instead of the app wizard.
- Add embedded youtube video for Vue launch talk at the top.