### PR TITLE
Community page: Fix twitter links

### DIFF
--- a/server/pages/community.html
+++ b/server/pages/community.html
@@ -89,7 +89,7 @@
                    loadgin="lazy">
           <strong>{{leader.leader_name}}</strong>
           {{ PrismicDOM.RichText.asHtml(leader.leader_bio if leader.leader_bio else '') }}
-          <a href="https://twitter.com/{{ leader.schlimmson }}" class="twitter" target="_blank">
+          <a href="https://twitter.com/{{ leader.twitter_handle }}" class="twitter" target="_blank">
             <ion-icon name="logo-twitter"></ion-icon>
           </a>
         </li>


### PR DESCRIPTION
Incorrect prismic prop id means links aren't rendering correctly